### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ satyrographos install
 After installation, you can import this package by writing the code in preamble.
 
 ```
-@require code-printer/code-printer
-@require code-printer/code-syntax
-@require code-printer/code-theme
+@require: code-printer/code-printer
+@require: code-printer/code-syntax
+@require: code-printer/code-theme
 ```
 
 # Usage


### PR DESCRIPTION
Hi, I'm new to satysfi. I'm looking for code highlighting package and finally installed this package.

Thus I found trivial typo in `README.md`. (because I'm new to satysfi, it may be valid in old satysfi) 