### PR TITLE
fix CR + LF merging. Basic tokens will disappear after CRLF. CRLFの直後にBasicトークンが来るとそのBasicトークンが消えるバグの修正．

### DIFF
--- a/src/code-printer.satyh
+++ b/src/code-printer.satyh
@@ -711,17 +711,20 @@ end = struct
         else
           List.reverse-append xs token-lst
       )
-      | x::y::zs when (is-LF x && is-CR y) -> organize (CRLF::token-lst) false null-string zs
       | x::ys -> (
           match x with
           | Basic(s) -> organize token-lst true (s^basic-str) ys
           | _ -> (
-            %%% トークンを分割
-            let xs = split-token-of-line x in
-            if is-basic then
-              organize (List.reverse-append xs ((Basic(basic-str))::token-lst)) false null-string ys
-            else
-              organize (List.reverse-append xs token-lst) false null-string ys
+            let token-lst2 =
+              if is-basic then ((Basic(basic-str))::token-lst) else token-lst
+            in
+            match ys with
+            | y::zs when (is-LF x && is-CR y) -> (organize (CRLF::token-lst2) false null-string zs)
+            | _ -> (
+              %%% トークンを分割
+              let xs = split-token-of-line x in
+              organize (List.reverse-append xs token-lst2) false null-string ys
+            )
           )
       )
     in


### PR DESCRIPTION
CR LFの並びをCRLFに変換する処理にバグがあり，CRLFの直後にBasicトークンが来るとそのBasicトークンが消えます．  
元のコードはCR LFの並びが来ると，`basic-str`を破棄して，CRLFを追加するようになっています．  
結果として，その直前で処理されていたBasicトークンが破棄されて出力されなくなります．  

When converting a combination of CR and LF into CRLF, there is a bug that basic tokens will disappear after CRLF.  
The original code adds CRLF with discarding `basic-str` when a combination of  CRLF is encountered.  
As a result, the previous Basic token will be discarded and not output.  

Example:  
```c
int main(void) <CR><LF>
{<CR><LF>
return 0;<CR><LF>
}
```
↓
```c
int main(void) <CRLF>
<CRLF>
return 0;<CRLF> // returnはkeywordなので消えない．return will not disappear because it is a keyword.

```

そこで，CRLFが来た場合にも，`basic-str`を処理するように修正しました．  
doc/code-printer-ja.saty をそのままコンパイルした場合でも，CRLFに変換してからコンパイルした場合でも正常に動作することを確認しました．  

So, in this commit, when coming a CRLF, `basic-str` will not be discarded.  
I checked that it works correctly with doc/code-printer-ja.saty with/without changing the newline into CRLF.